### PR TITLE
Fix collection serialization

### DIFF
--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -116,6 +116,19 @@ trait HasParent
 
         return (new $parentClass)->getMorphClass();
     }
+    
+    /**
+     * Get the class name for polymorphic relations.
+     *
+     * @return string
+     * @throws ReflectionException
+     */
+    public function getClassNameForSerialization(): string
+    {
+        $parentClass = $this->getParentClass();
+
+        return (new $parentClass)->getMorphClass();
+    }
 
     /**
      * Get the class name for Parent Class.

--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -118,16 +118,14 @@ trait HasParent
     }
     
     /**
-     * Get the class name for polymorphic relations.
+     * Get the class name for poly-type collections
      *
      * @return string
      * @throws ReflectionException
      */
     public function getClassNameForSerialization(): string
     {
-        $parentClass = $this->getParentClass();
-
-        return (new $parentClass)->getMorphClass();
+        return $this->getParentClass();
     }
 
     /**


### PR DESCRIPTION
Update HasParent.php to fix collection serialization.

Currently Parental creates unserializable Eloquent collections resulting in an error when pushing the colleciton to queue

Queueing collections with multiple model types is not supported.

I merged a framework request to create this callback on the model to circumvent the issue. https://github.com/laravel/framework/pull/44272

This should fix the serialization error.